### PR TITLE
READMEのコマンドが動かないので修正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ $ ./ecs_list_all_task_defs.sh > all_task_def.txt
 Listup running ECS task definitions.
 
 ```
-$ ./ecs_list_running_task_defs.sh > running_task_def.sh
+$ ./ecs_list_running_task_defs.sh > running_task_def.txt
 ```
 
 Listup unused ECS task definitions.
 
 ```
-$ ./ecs_list_unused_task_defs.sh all_task_def.sh running_task_def.sh > unused_task_def.txt
+$ ./ecs_list_unused_task_defs.sh all_task_def.txt running_task_def.txt > unused_task_def.txt
 ```
 
 Deregister ECS task definitions.
 
 ```
-$ ./ecs_deregister_unused_task_def.sh unused_task_def.sh
+$ ./ecs_deregister_unused_task_def.sh unused_task_def.txt
 ```
 
 # Pre require


### PR DESCRIPTION
拡張子がshだったりtxtだったり揺れていたので、txtに置き換えて動くようにする